### PR TITLE
Option to override default date pattern in properties

### DIFF
--- a/src/java/fr/paris/lutece/plugins/geocodesclient/rs/Constants.java
+++ b/src/java/fr/paris/lutece/plugins/geocodesclient/rs/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,7 +36,7 @@ package fr.paris.lutece.plugins.geocodesclient.rs;
 /**
  * Rest Constants
  */
-public final class Constants 
+public final class Constants
 {
     public static final String API_PATH = "geocodesclient/api";
     public static final String VERSION_PATH = "/v{" + Constants.VERSION + "}";
@@ -50,40 +50,40 @@ public final class Constants
     public static final String DATE = "dateref";
     public static final String SEARCH_DATE_AND_CODE = "/{" + Constants.ID + "}";
     public static final String ADDITIONAL_PARAM = "additionalParam";
-    
+
     public static final String SWAGGER_DIRECTORY_PATH = "/plugins/";
     public static final String SWAGGER_PATH = "/swagger";
     public static final String SWAGGER_VERSION_PATH = "/v";
     public static final String SWAGGER_REST_PATH = "rest/";
     public static final String SWAGGER_JSON = "/swagger.json";
-    
+
     public static final String EMPTY_OBJECT = "{}";
     public static final String ERROR_NOT_FOUND_VERSION = "Version not found";
     public static final String ERROR_NOT_FOUND_RESOURCE = "Resource not found";
     public static final String ERROR_SEARCH_STRING = "Search string must contain 3 chars at least";
     public static final String ERROR_BAD_REQUEST_EMPTY_PARAMETER = "Empty parameter";
-    
+
     public static final String CITY_PATH = "/cities";
     public static final String CITY_CODE_PATH = "/city";
     public static final String CITY_ATTRIBUTE_CODE_COUNTRY = "code_country";
     public static final String CITY_ATTRIBUTE_CODE = "code";
     public static final String CITY_ATTRIBUTE_VALUE = "value";
     public static final String CITY_ATTRIBUTE_CODE_ZONE = "code_zone";
-    
+
     public static final String COUNTRY_PATH = "/countries";
     public static final String COUNTRY_CODE_PATH = "/country";
     public static final String COUNTRY_ATTRIBUTE_CODE = "code";
     public static final String COUNTRY_ATTRIBUTE_VALUE = "value";
-    
+
     public static final String ID_PROVIDER_GEOCODE_LOCAL = "geocodes.geoCodeProviderLocal";
     public static final String ID_PROVIDER_GEOCODE_INSEE = "geocodes.geoCodeProviderINSEE";
-    
+
     public static final String CONST_DATE_MIN = "1943-01-01";
-    
+
     /**
      * Private constructor
      */
-    private Constants(  )
+    private Constants( )
     {
     }
 }

--- a/src/java/fr/paris/lutece/plugins/geocodesclient/rs/GeocodesRest.java
+++ b/src/java/fr/paris/lutece/plugins/geocodesclient/rs/GeocodesRest.java
@@ -34,11 +34,18 @@
 
 package fr.paris.lutece.plugins.geocodesclient.rs;
 
-import java.util.Date;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
+import fr.paris.lutece.plugins.geocode.v1.web.rs.dto.City;
+import fr.paris.lutece.plugins.geocode.v1.web.rs.dto.Country;
+import fr.paris.lutece.plugins.geocode.v1.web.service.GeoCodeService;
+import fr.paris.lutece.plugins.rest.service.RestConstants;
+import fr.paris.lutece.portal.service.spring.SpringContextService;
+import fr.paris.lutece.portal.service.util.AppLogService;
+import fr.paris.lutece.portal.service.util.AppPropertiesService;
+import fr.paris.lutece.util.date.DateUtil;
+import fr.paris.lutece.util.json.ErrorJsonResponse;
+import fr.paris.lutece.util.json.JsonResponse;
+import fr.paris.lutece.util.json.JsonUtil;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -47,17 +54,13 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import fr.paris.lutece.plugins.geocode.v1.web.rs.dto.City;
-import fr.paris.lutece.plugins.geocode.v1.web.rs.dto.Country;
-import fr.paris.lutece.plugins.geocode.v1.web.service.GeoCodeService;
-import fr.paris.lutece.plugins.rest.service.RestConstants;
-import fr.paris.lutece.portal.service.spring.SpringContextService;
-import fr.paris.lutece.portal.service.util.AppLogService;
-import fr.paris.lutece.util.date.DateUtil;
-import fr.paris.lutece.util.json.ErrorJsonResponse;
-import fr.paris.lutece.util.json.JsonResponse;
-import fr.paris.lutece.util.json.JsonUtil;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * CityRest
@@ -65,10 +68,25 @@ import fr.paris.lutece.util.json.JsonUtil;
 @Path( RestConstants.BASE_PATH + Constants.API_PATH + Constants.VERSION_PATH  )
 public class GeocodesRest
 {
-	private static final int VERSION_1 = 1;
-	private static final String GEOCODE_BEAN_NAME = "geocodes.geoCodesService";
+    private static final int VERSION_1 = 1;
+    private static final String GEOCODE_BEAN_NAME = "geocodes.geoCodesService";
+    private static final DateFormat DEFAULT_DATEFORMAT;
+
     private GeoCodeService _geoCodesService;
-    		
+
+    static
+    {
+        final String datePatternFromProperty = AppPropertiesService.getProperty( "geocodes.override.default.date.pattern" );
+        if ( StringUtils.isNotBlank( datePatternFromProperty ) )
+        {
+            DEFAULT_DATEFORMAT = new SimpleDateFormat( datePatternFromProperty );
+        }
+        else
+        {
+            DEFAULT_DATEFORMAT = DateUtil.getDateFormat( Locale.FRANCE );
+        }
+    }
+
     /**
      * Get City List with date
      * @param nVersion the API version
@@ -85,10 +103,14 @@ public class GeocodesRest
     {
         if ( nVersion == VERSION_1 )
         {
-        	// TODO: put date format in properties
-            Date dateref = DateUtil.formatDate(strDateRef, Locale.FRANCE);
-            
-        	return getCityListByNameAndDateV1( strVal, dateref);
+            final Date dateref;
+            try {
+                dateref = DEFAULT_DATEFORMAT.parse(strDateRef);
+            } catch (final ParseException e) {
+                AppLogService.error( e.getMessage() );
+                return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
+            }
+            return getCityListByNameAndDateV1( strVal, dateref);
         }
         AppLogService.error( Constants.ERROR_NOT_FOUND_VERSION );
         return Response.status( Response.Status.NOT_FOUND )
@@ -157,8 +179,13 @@ public class GeocodesRest
     {
         if ( nVersion == VERSION_1 )
         {
-        	// TODO: put date format in properties
-            Date dateref = DateUtil.formatDate(strDateRef, Locale.FRANCE);
+            final Date dateref;
+            try {
+                dateref = DEFAULT_DATEFORMAT.parse(strDateRef);
+            } catch (final ParseException e) {
+                AppLogService.error( e.getMessage() );
+                return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
+            }
         	return getCityByCodeAndDateV1( strCode, dateref );
         }
         AppLogService.error( Constants.ERROR_NOT_FOUND_VERSION );
@@ -202,8 +229,13 @@ public class GeocodesRest
     {
         if ( nVersion == VERSION_1 )
         {
-        	// TODO: put date format in properties
-            Date dateref = DateUtil.formatDate(strDateRef, Locale.FRANCE);
+            final Date dateref;
+            try {
+                dateref = DEFAULT_DATEFORMAT.parse(strDateRef);
+            } catch (final ParseException e) {
+                AppLogService.error( e.getMessage() );
+                return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
+            }
         	return getCountryByCodeAndDateV1( strCode, dateref );
         }
         AppLogService.error( Constants.ERROR_NOT_FOUND_VERSION );
@@ -248,9 +280,13 @@ public class GeocodesRest
     {
         if ( nVersion == VERSION_1 )
         {
-        	// TODO: put date format in properties
-            Date dateref = DateUtil.formatDate(strDateRef, Locale.FRANCE);
-            
+            final Date dateref;
+            try {
+                dateref = DEFAULT_DATEFORMAT.parse(strDateRef);
+            } catch (final ParseException e) {
+                AppLogService.error( e.getMessage() );
+                return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
+            }
             return getCountriesListByNameAndDateV1( strVal, dateref );
         }
         

--- a/src/java/fr/paris/lutece/plugins/geocodesclient/rs/GeocodesRest.java
+++ b/src/java/fr/paris/lutece/plugins/geocodesclient/rs/GeocodesRest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,6 @@
  *
  * License 1.0
  */
-
 package fr.paris.lutece.plugins.geocodesclient.rs;
 
 import fr.paris.lutece.plugins.geocode.v1.web.rs.dto.City;
@@ -65,7 +64,7 @@ import java.util.Locale;
 /**
  * CityRest
  */
-@Path( RestConstants.BASE_PATH + Constants.API_PATH + Constants.VERSION_PATH  )
+@Path( RestConstants.BASE_PATH + Constants.API_PATH + Constants.VERSION_PATH )
 public class GeocodesRest
 {
     private static final int VERSION_1 = 1;
@@ -89,46 +88,51 @@ public class GeocodesRest
 
     /**
      * Get City List with date
-     * @param nVersion the API version
-     * @param strVal the search string
-     * @param dateRef the reference date
+     * 
+     * @param nVersion
+     *            the API version
+     * @param strVal
+     *            the search string
+     * @param dateRef
+     *            the reference date
      * @return the City List
      */
     @GET
     @Path( Constants.CITY_PATH )
     @Produces( MediaType.APPLICATION_JSON )
-    public Response getCityListByDate( @PathParam( Constants.VERSION ) Integer nVersion,
-    							@QueryParam( Constants.SEARCHED_STRING ) String strVal,
-    							@QueryParam( Constants.ADDITIONAL_PARAM ) String strDateRef ) 
+    public Response getCityListByDate( @PathParam( Constants.VERSION ) Integer nVersion, @QueryParam( Constants.SEARCHED_STRING ) String strVal,
+            @QueryParam( Constants.ADDITIONAL_PARAM ) String strDateRef )
     {
         if ( nVersion == VERSION_1 )
         {
             final Date dateref;
-            try {
-                dateref = DEFAULT_DATEFORMAT.parse(strDateRef);
-            } catch (final ParseException e) {
-                AppLogService.error( e.getMessage() );
-                return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
+            try
+            {
+                dateref = DEFAULT_DATEFORMAT.parse( strDateRef );
             }
-            return getCityListByNameAndDateV1( strVal, dateref);
+            catch( final ParseException e )
+            {
+                AppLogService.error( e.getMessage( ) );
+                return Response.status( Response.Status.BAD_REQUEST ).entity( e.getMessage( ) ).build( );
+            }
+            return getCityListByNameAndDateV1( strVal, dateref );
         }
         AppLogService.error( Constants.ERROR_NOT_FOUND_VERSION );
         return Response.status( Response.Status.NOT_FOUND )
-                .entity( JsonUtil.buildJsonResponse( new ErrorJsonResponse( Response.Status.NOT_FOUND.name( ), Constants.ERROR_NOT_FOUND_VERSION ) ) )
-                .build( );
+                .entity( JsonUtil.buildJsonResponse( new ErrorJsonResponse( Response.Status.NOT_FOUND.name( ), Constants.ERROR_NOT_FOUND_VERSION ) ) ).build( );
     }
-    
+
     /**
      * init geocode service
      */
-    private void init()
+    private void init( )
     {
-    	if ( _geoCodesService == null)
-    	{
-    		_geoCodesService = SpringContextService.getBean( GEOCODE_BEAN_NAME );
-    	}
+        if ( _geoCodesService == null )
+        {
+            _geoCodesService = SpringContextService.getBean( GEOCODE_BEAN_NAME );
+        }
     }
-    
+
     /**
      * set display values
      * 
@@ -136,187 +140,210 @@ public class GeocodesRest
      */
     private void fillCitiesDisplayValues( List<City> lstCities )
     {
-    	lstCities.stream( ).forEach( c -> c.setDisplayValue(  c.getValue() + " (" + c.getCodeZone() + ")" ) );
+        lstCities.stream( ).forEach( c -> c.setDisplayValue( c.getValue( ) + " (" + c.getCodeZone( ) + ")" ) );
     }
-    
+
     /**
      * Get City List V1
+     * 
      * @return the City List for the version 1
      */
     private Response getCityListByNameAndDateV1( String strSearchBeginningVal, Date dateCity )
     {
-    	List<City> lstCities = new ArrayList<>( );
-    	
+        List<City> lstCities = new ArrayList<>( );
+
         if ( strSearchBeginningVal != null || strSearchBeginningVal.length( ) >= 3 )
         {
-        	try {
-        		init( );
-    			lstCities = _geoCodesService.getListCitiesByNameAndDateLike( strSearchBeginningVal, dateCity );
-    			fillCitiesDisplayValues( lstCities );
-    		} catch (Exception e) {
-    			AppLogService.error( e );
-    		}
+            try
+            {
+                init( );
+                lstCities = _geoCodesService.getListCitiesByNameAndDateLike( strSearchBeginningVal, dateCity );
+                fillCitiesDisplayValues( lstCities );
+            }
+            catch( Exception e )
+            {
+                AppLogService.error( e );
+            }
         }
 
-        return Response.status( Response.Status.OK )
-                .entity( JsonUtil.buildJsonResponse( new JsonResponse( lstCities ) ) )
-                .build( );
+        return Response.status( Response.Status.OK ).entity( JsonUtil.buildJsonResponse( new JsonResponse( lstCities ) ) ).build( );
     }
-    
+
     /**
      * Get City with date
-     * @param nVersion the API version
-     * @param strCode the search string
-     * @param dateRef the reference date
+     * 
+     * @param nVersion
+     *            the API version
+     * @param strCode
+     *            the search string
+     * @param dateRef
+     *            the reference date
      * @return the City List
      */
     @GET
     @Path( Constants.CITY_PATH + Constants.CITY_CODE_PATH )
     @Produces( MediaType.APPLICATION_JSON )
-    public Response getCityByCodeAndDate( @PathParam( Constants.VERSION ) Integer nVersion,
-    							@QueryParam( Constants.SEARCHED_CODE ) String strCode,
-    							@QueryParam( Constants.ADDITIONAL_PARAM ) String strDateRef ) 
+    public Response getCityByCodeAndDate( @PathParam( Constants.VERSION ) Integer nVersion, @QueryParam( Constants.SEARCHED_CODE ) String strCode,
+            @QueryParam( Constants.ADDITIONAL_PARAM ) String strDateRef )
     {
         if ( nVersion == VERSION_1 )
         {
             final Date dateref;
-            try {
-                dateref = DEFAULT_DATEFORMAT.parse(strDateRef);
-            } catch (final ParseException e) {
-                AppLogService.error( e.getMessage() );
-                return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
+            try
+            {
+                dateref = DEFAULT_DATEFORMAT.parse( strDateRef );
             }
-        	return getCityByCodeAndDateV1( strCode, dateref );
+            catch( final ParseException e )
+            {
+                AppLogService.error( e.getMessage( ) );
+                return Response.status( Response.Status.BAD_REQUEST ).entity( e.getMessage( ) ).build( );
+            }
+            return getCityByCodeAndDateV1( strCode, dateref );
         }
         AppLogService.error( Constants.ERROR_NOT_FOUND_VERSION );
         return Response.status( Response.Status.NOT_FOUND )
-                .entity( JsonUtil.buildJsonResponse( new ErrorJsonResponse( Response.Status.NOT_FOUND.name( ), Constants.ERROR_NOT_FOUND_VERSION ) ) )
-                .build( );
+                .entity( JsonUtil.buildJsonResponse( new ErrorJsonResponse( Response.Status.NOT_FOUND.name( ), Constants.ERROR_NOT_FOUND_VERSION ) ) ).build( );
     }
-    
+
     /**
      * Get City by code and date V1
+     * 
      * @return the City for the version 1
      */
     private Response getCityByCodeAndDateV1( String strCode, Date dateCity )
     {
-    	City city = new City( );
-    	try {
-    		init( );
-    		city = _geoCodesService.getCityByCodeAndDate( strCode, dateCity );
-		} catch (Exception e) {
-			AppLogService.error( e );
-		}
+        City city = new City( );
+        try
+        {
+            init( );
+            city = _geoCodesService.getCityByCodeAndDate( strCode, dateCity );
+        }
+        catch( Exception e )
+        {
+            AppLogService.error( e );
+        }
 
-        return Response.status( Response.Status.OK )
-                .entity( JsonUtil.buildJsonResponse( new JsonResponse( city ) ) )
-                .build( );
+        return Response.status( Response.Status.OK ).entity( JsonUtil.buildJsonResponse( new JsonResponse( city ) ) ).build( );
     }
-    
+
     /**
      * Get City with date
-     * @param nVersion the API version
-     * @param strCode the search string
-     * @param dateRef the reference date
+     * 
+     * @param nVersion
+     *            the API version
+     * @param strCode
+     *            the search string
+     * @param dateRef
+     *            the reference date
      * @return the City List
      */
     @GET
     @Path( Constants.COUNTRY_PATH + Constants.COUNTRY_CODE_PATH )
     @Produces( MediaType.APPLICATION_JSON )
-    public Response getCountryByCodeAndDate( @PathParam( Constants.VERSION ) Integer nVersion,
-    							@QueryParam( Constants.SEARCHED_CODE ) String strCode,
-    							@QueryParam( Constants.ADDITIONAL_PARAM ) String strDateRef ) 
+    public Response getCountryByCodeAndDate( @PathParam( Constants.VERSION ) Integer nVersion, @QueryParam( Constants.SEARCHED_CODE ) String strCode,
+            @QueryParam( Constants.ADDITIONAL_PARAM ) String strDateRef )
     {
         if ( nVersion == VERSION_1 )
         {
             final Date dateref;
-            try {
-                dateref = DEFAULT_DATEFORMAT.parse(strDateRef);
-            } catch (final ParseException e) {
-                AppLogService.error( e.getMessage() );
-                return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
+            try
+            {
+                dateref = DEFAULT_DATEFORMAT.parse( strDateRef );
             }
-        	return getCountryByCodeAndDateV1( strCode, dateref );
+            catch( final ParseException e )
+            {
+                AppLogService.error( e.getMessage( ) );
+                return Response.status( Response.Status.BAD_REQUEST ).entity( e.getMessage( ) ).build( );
+            }
+            return getCountryByCodeAndDateV1( strCode, dateref );
         }
         AppLogService.error( Constants.ERROR_NOT_FOUND_VERSION );
         return Response.status( Response.Status.NOT_FOUND )
-                .entity( JsonUtil.buildJsonResponse( new ErrorJsonResponse( Response.Status.NOT_FOUND.name( ), Constants.ERROR_NOT_FOUND_VERSION ) ) )
-                .build( );
+                .entity( JsonUtil.buildJsonResponse( new ErrorJsonResponse( Response.Status.NOT_FOUND.name( ), Constants.ERROR_NOT_FOUND_VERSION ) ) ).build( );
     }
-    
+
     /**
      * Get City by code and date V1
+     * 
      * @return the City for the version 1
      */
     private Response getCountryByCodeAndDateV1( String strCode, Date dateCity )
     {
-    	Country country = new Country( );
-    	try {
-    		init( );
-    		country = _geoCodesService.getCountryByCodeAndDate( strCode, dateCity );
-		} catch (Exception e) {
-			AppLogService.error( e );
-		}
+        Country country = new Country( );
+        try
+        {
+            init( );
+            country = _geoCodesService.getCountryByCodeAndDate( strCode, dateCity );
+        }
+        catch( Exception e )
+        {
+            AppLogService.error( e );
+        }
 
-        return Response.status( Response.Status.OK )
-                .entity( JsonUtil.buildJsonResponse( new JsonResponse( country ) ) )
-                .build( );
+        return Response.status( Response.Status.OK ).entity( JsonUtil.buildJsonResponse( new JsonResponse( country ) ) ).build( );
     }
-    
+
     /**
      * Search Countries
-     * @param nVersion the API version
-     * @param search the searched string
-     * @param dateRef the reference date
+     * 
+     * @param nVersion
+     *            the API version
+     * @param search
+     *            the searched string
+     * @param dateRef
+     *            the reference date
      * @return the Countries
      */
     @GET
     @Path( Constants.COUNTRY_PATH )
     @Produces( MediaType.APPLICATION_JSON )
-    public Response getCountiesListByNameAndDate(
-			    @PathParam( Constants.VERSION ) Integer nVersion,
-			    @QueryParam( Constants.SEARCHED_STRING ) String strVal,
-			    @QueryParam( Constants.ADDITIONAL_PARAM ) String strDateRef )
+    public Response getCountiesListByNameAndDate( @PathParam( Constants.VERSION ) Integer nVersion, @QueryParam( Constants.SEARCHED_STRING ) String strVal,
+            @QueryParam( Constants.ADDITIONAL_PARAM ) String strDateRef )
     {
         if ( nVersion == VERSION_1 )
         {
             final Date dateref;
-            try {
-                dateref = DEFAULT_DATEFORMAT.parse(strDateRef);
-            } catch (final ParseException e) {
-                AppLogService.error( e.getMessage() );
-                return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
+            try
+            {
+                dateref = DEFAULT_DATEFORMAT.parse( strDateRef );
+            }
+            catch( final ParseException e )
+            {
+                AppLogService.error( e.getMessage( ) );
+                return Response.status( Response.Status.BAD_REQUEST ).entity( e.getMessage( ) ).build( );
             }
             return getCountriesListByNameAndDateV1( strVal, dateref );
         }
-        
+
         AppLogService.error( Constants.ERROR_NOT_FOUND_VERSION );
         return Response.status( Response.Status.NOT_FOUND )
-                .entity( JsonUtil.buildJsonResponse( new ErrorJsonResponse( Response.Status.NOT_FOUND.name( ), Constants.ERROR_NOT_FOUND_VERSION ) ) )
-                .build( );
+                .entity( JsonUtil.buildJsonResponse( new ErrorJsonResponse( Response.Status.NOT_FOUND.name( ), Constants.ERROR_NOT_FOUND_VERSION ) ) ).build( );
     }
-    
+
     /**
      * Get Country V1
-     * @param id the id
+     * 
+     * @param id
+     *            the id
      * @return the Country for the version 1
      */
     private Response getCountriesListByNameAndDateV1( String strSearchBeginningVal, Date dateRef )
     {
-    	List<Country> listCountries = new ArrayList<>();
-    	
+        List<Country> listCountries = new ArrayList<>( );
+
         if ( strSearchBeginningVal != null && strSearchBeginningVal.length( ) > 3 )
         {
-        	try {
-        		init( );
-        		listCountries = _geoCodesService.getListCountryByNameAndDate( strSearchBeginningVal, dateRef );
-    		} catch (Exception e) {
-    			AppLogService.error( e );
-    		}
+            try
+            {
+                init( );
+                listCountries = _geoCodesService.getListCountryByNameAndDate( strSearchBeginningVal, dateRef );
+            }
+            catch( Exception e )
+            {
+                AppLogService.error( e );
+            }
         }
-        
-        return Response.status( Response.Status.OK )
-                .entity( JsonUtil.buildJsonResponse( new JsonResponse( listCountries ) ) )
-                .build( );
+
+        return Response.status( Response.Status.OK ).entity( JsonUtil.buildJsonResponse( new JsonResponse( listCountries ) ) ).build( );
     }
 }

--- a/src/test/java/fr/paris/lutece/plugins/geocodesclient/web/DefaultTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/geocodesclient/web/DefaultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, City of Paris
+ * Copyright (c) 2002-2024, City of Paris
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,7 +23,7 @@
  * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
  * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES LOSS OF USE, DATA, OR PROFITS OR BUSINESS
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
@@ -31,21 +31,19 @@
  *
  * License 1.0
  */
-
 package fr.paris.lutece.plugins.geocodesclient.web;
 
-
 import fr.paris.lutece.test.LuteceTestCase;
+
 /**
- * This is the business class test 
+ * This is the business class test
  */
 public class DefaultTest extends LuteceTestCase
 {
 
+    public void testDefault( )
+    {
+        assertTrue( true );
 
-	public void testDefault(  ) 
-	{	
-     	 assertTrue( true );
-     
-	}
+    }
 }

--- a/webapp/WEB-INF/conf/plugins/geocodesclient.properties
+++ b/webapp/WEB-INF/conf/plugins/geocodesclient.properties
@@ -8,3 +8,5 @@ geocodes.pagePathLabel=geocodesclient
 geocodes.identitystore.ApiEndPointUrl=/path/to/apim/gateway
 geocodes.identitystore.accessManagerEndPointUrl=/path/to/am/token
 geocodes.identitystore.accessManagerCredentials=<token>
+
+geocodes.override.default.date.pattern=


### PR DESCRIPTION
small evol to give the option to override the default date pattern by filling the property `geocodes.override.default.date.pattern`.
if this property stays blank, then the default previous behaviour is applied (taking the date format for the locale FRANCE).